### PR TITLE
fix broken link to hexdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![VintageNet logo](assets/logo.png)
 
 [![Hex version](https://img.shields.io/hexpm/v/vintage_net_bridge.svg "Hex version")](https://hex.pm/packages/vintage_net_bridge)
-[![API docs](https://img.shields.io/hexpm/v/vintage_net_bridge.svg?label=hexdocs "API docs")](https://hexdocs.pm/vintage_net_bridge/VintageNetEthernet.html)
+[![API docs](https://img.shields.io/hexpm/v/vintage_net_bridge.svg?label=hexdocs "API docs")](https://hexdocs.pm/vintage_net_bridge/VintageNetBridge.html)
 [![CircleCI](https://circleci.com/gh/nerves-networking/vintage_net_bridge.svg?style=svg)](https://circleci.com/gh/nerves-networking/vintage_net_bridge)
 [![Coverage Status](https://coveralls.io/repos/github/nerves-networking/vintage_net_bridge/badge.svg?branch=master)](https://coveralls.io/github/nerves-networking/vintage_net_bridge?branch=master)
 


### PR DESCRIPTION
I found the link on the "hexdocs" budge was wrong.