### PR TITLE
Fix error caused by non-normalization

### DIFF
--- a/lib/vintage_net_bridge.ex
+++ b/lib/vintage_net_bridge.ex
@@ -40,7 +40,12 @@ defmodule VintageNetBridge do
   alias VintageNetBridge.Server
 
   @impl VintageNet.Technology
-  def normalize(config), do: config
+  def normalize(config) do
+    config
+    |> IPv4Config.normalize()
+    |> DhcpdConfig.normalize()
+    |> DnsdConfig.normalize()
+  end
 
   @impl VintageNet.Technology
   def to_raw_config(ifname, config, opts) do


### PR DESCRIPTION
The error log is below,

```
05:06:45.182 [error] GenStateMachine {VintageNet.Interface.Registry, "br0"} terminating
** (MatchError) no match of right hand side value: {:error, "Configuration has an unrecoverable error:\n\n:function_clause\n\n    (vintage_net 0.13.4) lib/vintage_net/ip.ex:222: VintageNet.IP.ipv4_broadcast_address(\"169.254.169.254\", 16)\n    (vintage_net 0.13.4) lib/vintage_net/ip/ipv4_config.ex:206: VintageNet.IP.IPv4Config.add_config/3\n    (vintage_net_bridge 0.10.1) lib/vintage_net_bridge.ex:77: VintageNetBridge.to_raw_config/3\n    (vintage_net 0.13.4) lib/vintage_net/interface.ex:69: VintageNet.Interface.to_raw_config/2\n    (vintage_net 0.13.4) lib/vintage_net/interface.ex:207: VintageNet.Interface.get_raw_config/1\n    (vintage_net 0.13.4) lib/vintage_net/interface.ex:189: VintageNet.Interface.init/1\n    (stdlib 5.0.2) gen_statem.erl:966: :gen_statem.init_it/6\n    (stdlib 5.0.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3\n\n"}
    (vintage_net 0.13.4) lib/vintage_net/interface.ex:207: VintageNet.Interface.get_raw_config/1
    (vintage_net 0.13.4) lib/vintage_net/interface.ex:189: VintageNet.Interface.init/1
    (stdlib 5.0.2) gen_statem.erl:966: :gen_statem.init_it/6
    (stdlib 5.0.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
```

I referenced the following codes to make this fix,

- https://github.com/nerves-networking/vintage_net_bridge/blob/bed064bcad0614bb538247c3433b423690dec58d/lib/vintage_net_bridge.ex#L77-L79
- https://github.com/nerves-networking/vintage_net_wifi/blob/3451bd8dfb552c44f01880efabc67055ce36a947/lib/vintage_net_wifi.ex#L106-L112
- https://github.com/nerves-networking/vintage_net_ethernet/blob/f408bfd931ed02775dad090d7925e71c6b4267c6/lib/vintage_net_ethernet.ex#L46-L51

and I have confirmed with rpi4 that this fix fixes the error.

But I'm not familiar with vintage_net code, so there may be more to fix. Could you check this PR?