### PR TITLE
Add a command to clean up the bridge before creating the new one

### DIFF
--- a/lib/vintage_net_bridge.ex
+++ b/lib/vintage_net_bridge.ex
@@ -54,6 +54,7 @@ defmodule VintageNetBridge do
     interfaces = Map.fetch!(bridge_config, :interfaces)
 
     up_cmds = [
+      {:run_ignore_errors, "brctl", ["delbr", ifname]},
       {:run, "brctl", ["addbr", ifname]}
     ]
 

--- a/test/vintage_net_bridge_test.exs
+++ b/test/vintage_net_bridge_test.exs
@@ -29,6 +29,7 @@ defmodule VintageNetBridgeTest do
         {:run, "ip", ["link", "set", "br0", "down"]}
       ],
       up_cmds: [
+        {:run_ignore_errors, "brctl", ["delbr", "br0"]},
         {:run, "brctl", ["addbr", "br0"]},
         {:run_ignore_errors, "brctl", ["addif", "br0", "eth0"]},
         {:run_ignore_errors, "brctl", ["addif", "br0", "mesh0"]},
@@ -74,6 +75,7 @@ defmodule VintageNetBridgeTest do
         {:run, "ip", ["link", "set", "br0", "down"]}
       ],
       up_cmds: [
+        {:run_ignore_errors, "brctl", ["delbr", "br0"]},
         {:run, "brctl", ["addbr", "br0"]},
         {:run, "brctl", ["setfd", "br0", "1"]},
         {:run, "brctl", ["hairpin", "br0", "7", "no"]},
@@ -133,6 +135,7 @@ defmodule VintageNetBridgeTest do
         {:run, "ip", ["link", "set", "br0", "down"]}
       ],
       up_cmds: [
+        {:run_ignore_errors, "brctl", ["delbr", "br0"]},
         {:run, "brctl", ["addbr", "br0"]},
         {:run_ignore_errors, "brctl", ["addif", "br0", "eth0"]},
         {:run_ignore_errors, "brctl", ["addif", "br0", "tap0"]},


### PR DESCRIPTION
If a failure occurs when executing `addif` of up_cmds, subsequent retries of configuring the bridge always fail.
This is because the first run of `addbr` created the bridge, so the retry `addbr` fails.

This PR fixes #107 .