### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![VintageNet logo](assets/logo.png)
 
 [![Hex version](https://img.shields.io/hexpm/v/vintage_net_bridge.svg "Hex version")](https://hex.pm/packages/vintage_net_bridge)
-[![API docs](https://img.shields.io/hexpm/v/vintage_net_bridge.svg?label=hexdocs "API docs")](https://hexdocs.pm/vintage_net_bridge/VintageNetBridge.html)
+[![API docs](https://img.shields.io/hexpm/v/vintage_net_bridge.svg?label=hexdocs "API docs")](https://vintage-net-bridge.hexdocs.pm/VintageNetBridge.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-networking/vintage_net_bridge/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-networking/vintage_net_bridge/tree/main)
 [![Coverage Status](https://coveralls.io/repos/github/nerves-networking/vintage_net_bridge/badge.svg)](https://coveralls.io/github/nerves-networking/vintage_net_bridge)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-networking/vintage_net_bridge)](https://api.reuse.software/info/github.com/nerves-networking/vintage_net_bridge)


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://vintage-net-bridge.hexdocs.pm/VintageNetBridge.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>